### PR TITLE
Initialization fixes for v2018.1.x

### DIFF
--- a/gluon-ssid-changer/files/etc/config/ssid-changer
+++ b/gluon-ssid-changer/files/etc/config/ssid-changer
@@ -1,2 +1,1 @@
 config settings 'settings'
-  option enabled '1'

--- a/gluon-ssid-changer/luasrc/lib/gluon/upgrade/500-ssid-changer
+++ b/gluon-ssid-changer/luasrc/lib/gluon/upgrade/500-ssid-changer
@@ -7,7 +7,7 @@ local uci = require('simple-uci').cursor()
 if site.ssid_changer == nil then
 	-- print('ssid_changer not defined in site.conf')
 elseif not uci:get('ssid-changer', 'settings', 'enabled') then
-	uci:section('ssid-changer', 'main', 'settings', {
+	uci:section('ssid-changer', 'settings', 'settings', {
 		enabled           = '1',
 		switch_timeframe  = site.ssid_changer.switch_timeframe() or '30',
 		first             = site.ssid_changer.first() or '5',

--- a/gluon-ssid-changer/luasrc/lib/gluon/upgrade/500-ssid-changer
+++ b/gluon-ssid-changer/luasrc/lib/gluon/upgrade/500-ssid-changer
@@ -9,13 +9,13 @@ if site.ssid_changer == nil then
 elseif not uci:get('ssid-changer', 'settings', 'enabled') then
 	uci:section('ssid-changer', 'main', 'settings', {
 		enabled           = '1',
-		switch_timeframe  = site.ssid_changer.switch_timeframe or '30',
-		first             = site.ssid_changer.first or '5',
-		prefix            = site.ssid_changer.prefix or 'FF_Offline_',
-		suffix            = site.ssid_changer.suffix or 'nodename',
-		tq_limit_enabled  = site.ssid_changer.tq_limit_enabled or false,
-		tq_limit_max      = site.ssid_changer.tq_limit_max or 45,
-		tq_limit_min      = site.ssid_changer.tq_limit_min or 35,
+		switch_timeframe  = site.ssid_changer.switch_timeframe() or '30',
+		first             = site.ssid_changer.first() or '5',
+		prefix            = site.ssid_changer.prefix() or 'FF_Offline_',
+		suffix            = site.ssid_changer.suffix() or 'nodename',
+		tq_limit_enabled  = site.ssid_changer.tq_limit_enabled() or false,
+		tq_limit_max      = site.ssid_changer.tq_limit_max() or 45,
+		tq_limit_min      = site.ssid_changer.tq_limit_min() or 35,
 	})
 	uci:save('ssid-changer')
 end

--- a/gluon-ssid-changer/luasrc/lib/gluon/upgrade/500-ssid-changer
+++ b/gluon-ssid-changer/luasrc/lib/gluon/upgrade/500-ssid-changer
@@ -6,9 +6,11 @@ local uci = require('simple-uci').cursor()
 
 if site.ssid_changer == nil then
 	-- print('ssid_changer not defined in site.conf')
-elseif not uci:get('ssid-changer', 'settings', 'enabled') then
+else
+	local site_enabled = site.ssid_changer.enabled() or '1'
+
 	uci:section('ssid-changer', 'settings', 'settings', {
-		enabled           = '1',
+		enabled           = uci:get('ssid-changer', 'settings', 'enabled') or site_enabled,
 		switch_timeframe  = site.ssid_changer.switch_timeframe() or '30',
 		first             = site.ssid_changer.first() or '5',
 		prefix            = site.ssid_changer.prefix() or 'FF_Offline_',


### PR DESCRIPTION
It was noticed that the package was not working at all on a fresh 2018.1.x installation. Here my report from IRC:

> rubo77|m: the gluon-ssid-changer which you've tried to promote doesn't really work. it doesn't write the config data to /etc/config/ssid-changer for the current gluon-master version
> there are a couple of problems:
> 1. you are trying to access the site data in your /lib/gluon/upgrade/500-ssid-changer like this: site.ssid_changer.prefix
>     but this will not return strings. you need to do it like (!parentheses at the end) this: site.ssid_changer.prefix()
> 2. you check in the upgrade script whether ssid-changer.settings.enabled and abort when it exists. but you've added a /etc/config/ssid-changer with exactly this data (and thus it aborts the initialization of the config data)
> 3. you create you uci config section in the upgrade script as ssid-changer.settings=main but all other places do it as ssid-changer.settings=settings